### PR TITLE
Make createServer API be consistent with httpServer on node core

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,6 +81,12 @@ Server.prototype.zone = function(zone, server, admin, serial, refresh, retry, ex
 
 Server.prototype.listen = function(port, ip, callback) {
   var self = this
+
+  if(typeof ip === 'function') {
+    callback = ip
+    ip = null
+  }
+
   self.port = port
   self.ip   = ip || '0.0.0.0'
 


### PR DESCRIPTION
I was trying to use `dnsd` like I normally call my http node server:

``` javascript
var dnsd = require('dnsd'),
      port = 3737

dnsd.createServer(function (req, res) {
  res.end('1.2.3.4')
}).listen(port, function () {
  console.log('started on %s', port) 
})
```

`dnsd` was wrongfully using the callback function as the ip, which caused side effects. 

This patch prevents this behavior and re-introduces the same api as node http create server.

I couldn't find how to add tests and documentation for this change, but will provide them at your request
