### PR TITLE
Authorative zone should be case insensitive

### DIFF
--- a/convenient.js
+++ b/convenient.js
@@ -47,7 +47,7 @@ function final_response(res, value) {
     , zone, soa_record
 
   while(names && names.length) {
-    zone = names.join('.')
+    zone = names.join('.').toLowerCase()
     names.shift()
 
     soa_record = res.connection.server.zones[zone]

--- a/server.js
+++ b/server.js
@@ -75,7 +75,7 @@ Server.prototype.zone = function(zone, server, admin, serial, refresh, retry, ex
                         }
              }
 
-  self.zones[record.name] = record
+  self.zones[record.name.toLowerCase()] = record
   return self
 }
 

--- a/test/convenience.js
+++ b/test/convenience.js
@@ -55,7 +55,7 @@ test('Authoritative response', function(t) {
   var out = convenient.final_response(msg)
   t.equal(out.authoritative, false, 'Final responses are not authoritative by default')
 
-  msg = new Message({'question':[{'class':'IN', 'type':'A', 'name':'foo.bar.example.com'}]})
+  msg = new Message({'question':[{'class':'IN', 'type':'A', 'name':'foo.bar.Example.com'}]})
   msg.authority = []
   msg.connection = {'server':server}
   out = convenient.final_response(msg)


### PR DESCRIPTION
The DNS server would not respond as an authoritative DNS server when the requested host had capital letters in it. The places where it does its comparison now converts it all to lowercase letters. The test has been updated to use an uppercase domain
