### PR TITLE
Support CAA record type

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -170,7 +170,13 @@ function mk_type_labels() {
     , 57: 'RKEY'
     , 58: 'TALINK'
     , 59: 'CDS'
-    // 60 - 98 unassigned
+    , 60: 'CDNSKEY'
+    , 61: 'OPENPGPKEY'
+    , 62: 'CSYNC'
+    , 63: 'ZONEMD'
+    , 64: 'SVCB'
+    , 65: 'HTTPS'
+    // 66 - 98 unassigned
     , 99: 'SPF'
     , 100: 'UINFO'
     , 101: 'UID'
@@ -198,7 +204,7 @@ function mk_type_labels() {
     , 65535: 'Reserved'
     }
 
-  var unassigned = [ [53,54], [60,98], [108,248], [258,32767], [32770,65279] ]
+  var unassigned = [ [53,54], [66,98], [108,248], [258,32767], [32770,65279] ]
   unassigned.forEach(function(pair) {
     var start = pair[0], stop = pair[1]
     for(var i = start; i <= stop; i++)

--- a/encode.js
+++ b/encode.js
@@ -156,6 +156,19 @@ State.prototype.record = function(section_name, record) {
       case 'IN CNAME':
         rdata = self.encode(record.data, 2) // Adjust for the rdata length
         break
+      case 'IN CAA':
+        buf = new Buffer(2)
+        switch (record.data.type) {
+          case 'issue':
+          case 'iodef':
+            buf.writeUInt16BE(5)
+            break
+          case 'issuewild':
+            buf.writeUInt16BE(9)
+            break
+        }
+        rdata = [buf, new Buffer(record.data.type + record.data.value)]
+        break
       case 'IN TXT':
         rdata = record.data.map(function(part) {
           part = new Buffer(part)

--- a/encode.js
+++ b/encode.js
@@ -158,15 +158,7 @@ State.prototype.record = function(section_name, record) {
         break
       case 'IN CAA':
         buf = new Buffer(2)
-        switch (record.data.type) {
-          case 'issue':
-          case 'iodef':
-            buf.writeUInt16BE(5)
-            break
-          case 'issuewild':
-            buf.writeUInt16BE(9)
-            break
-        }
+        buf.writeUInt16BE(record.data.type.length)
         rdata = [buf, new Buffer(record.data.type + record.data.value)]
         break
       case 'IN TXT':

--- a/encode.js
+++ b/encode.js
@@ -157,9 +157,11 @@ State.prototype.record = function(section_name, record) {
         rdata = self.encode(record.data, 2) // Adjust for the rdata length
         break
       case 'IN CAA':
-        buf = new Buffer(2)
-        buf.writeUInt16BE(record.data.type.length)
-        rdata = [buf, new Buffer(record.data.type + record.data.value)]
+        rdata = [ new Buffer([record.data.flags])
+                , new Buffer([record.data.type.length])
+                , new Buffer(record.data.type)
+                , new Buffer(record.data.value)
+                ]
         break
       case 'IN TXT':
         rdata = record.data.map(function(part) {

--- a/message.js
+++ b/message.js
@@ -2,6 +2,7 @@
 //
 // Test displaying DNS records
 
+var events = require('events')
 var util = require('util')
 
 var parse = require('./parse')
@@ -37,8 +38,10 @@ var SECTIONS = ['question', 'answer', 'authority', 'additional']
 // * toString() - return a human-readable representation of this message
 // * toJSON() - Return a JSON-friendly represenation of this message
 // * toBinary() - Return a buffer of the encoded message
+util.inherits(DNSMessage, events.EventEmitter)
 function DNSMessage (body) {
   var self = this
+  events.EventEmitter.call(self)
 
   this.id = null
   this.type                = null

--- a/server.js
+++ b/server.js
@@ -130,6 +130,7 @@ Server.prototype.on_tcp_connection = function(connection) {
   connection.type = 'tcp'
   connection.server = self
 
+  connection.on('error', self.emit.bind(self, 'error'))
   connection.on('data', function(data) {
     bufs.push(data)
     var bytes_received = bufs.reduce(function(state, buf) { return state + buf.length }, 0)
@@ -146,6 +147,9 @@ Server.prototype.on_tcp_connection = function(connection) {
         var data = Buffer.concat(bufs)
           , req = new Request(data, connection)
           , res = new Response(data, connection)
+
+        req.on('error', self.emit.bind(self, 'error'))
+        res.on('error', self.emit.bind(self, 'error'))
 
         self.emit('request', req, res)
       } catch (err) {
@@ -171,6 +175,9 @@ Server.prototype.on_udp = function(data, rinfo) {
   try {
     var req = new Request(data, connection)
       , res = new Response(data, connection)
+
+    req.on('error', self.emit.bind(self, 'error'))
+    res.on('error', self.emit.bind(self, 'error'))
 
     self.emit('request', req, res)
   } catch (err) {

--- a/server.js
+++ b/server.js
@@ -141,12 +141,16 @@ Server.prototype.on_tcp_connection = function(connection) {
     }
 
     if(length !== null && bytes_received == 2 + length) {
-      // All of the data (plus the 2-byte length prefix) is received.
-      var data = Buffer.concat(bufs)
-        , req = new Request(data, connection)
-        , res = new Response(data, connection)
+      try {
+        // All of the data (plus the 2-byte length prefix) is received.
+        var data = Buffer.concat(bufs)
+          , req = new Request(data, connection)
+          , res = new Response(data, connection)
 
-      self.emit('request', req, res)
+        self.emit('request', req, res)
+      } catch (err) {
+        self.emit('error', err);
+      }
     }
   })
 }
@@ -164,10 +168,14 @@ Server.prototype.on_udp = function(data, rinfo) {
                    , 'end'          : function() {}
                    }
 
-  var req = new Request(data, connection)
-    , res = new Response(data, connection)
+  try {
+    var req = new Request(data, connection)
+      , res = new Response(data, connection)
 
-  self.emit('request', req, res)
+    self.emit('request', req, res)
+  } catch (err) {
+    self.emit('error', err);
+  }
 }
 
 


### PR DESCRIPTION
Adds CAA record support to DNSD. This will help with CA validation.

The record seems to be an 8-bit flag, then an 8-bit length of the type, followed by the payload (type and value).

Values generated by this have been validated by using https://sslmate.com/caa/ and `dig  9.9.7-P3`

### Usage:
To get `0 issuewild "digicert.com"` to show up on your DNS records, you should use:
```
res.answer.push({name: question.name, type: 'CAA', data: { type: 'issuewild', value: 'digicert.com' }, 'ttl': ttl});
```

Fixes #19 